### PR TITLE
Terms and Condition checkbox validated

### DIFF
--- a/src/Pages/Authentication/SignUp.js
+++ b/src/Pages/Authentication/SignUp.js
@@ -229,10 +229,9 @@ function SignUp() {
   };
 
   // Showing pop-up window
-  const handleShow = (event) => {
-    // console.log(event);
-    setShow(true);
-  }
+  const handleShow = () => {
+      setShow(true);
+    }
 
   return (
     <Container fluid className="signUpWrapper">
@@ -464,9 +463,9 @@ function SignUp() {
                     data-validity={validity}
                     data-testid="termsCheckbox"
                     required
-                    onChange={handleShow}
+                    checked={agreeTerms && true}
                   />
-                  <Form.Check.Label className="p-2">Agree to terms and conditions</Form.Check.Label>
+                  <Form.Check.Label className="p-2">Agree to <Link to="/signup" onClick={handleShow}>terms and conditions</Link></Form.Check.Label>
                   <Form.Control.Feedback type="invalid">Please agree to terms and conditions</Form.Control.Feedback>
                 </Form.Group>
                 <div className="formFooter d-flex align-items-center justify-content-center flex-column mb-1">


### PR DESCRIPTION
When clicked on the terms and conditions text, a modal with dummy text should pop up and there should be an accept or decline button. When clicking on accept, change the checkbox in the login page to an accepted state.